### PR TITLE
Add php version to styleci config

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,1 +1,3 @@
 preset: laravel
+
+version: 8


### PR DESCRIPTION
This pr adds the php version 8 to the styleci config.