### PR TITLE
Add fallback html loader

### DIFF
--- a/src/IndexerServiceProvider.php
+++ b/src/IndexerServiceProvider.php
@@ -16,6 +16,8 @@ class IndexerServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->mergeConfigFrom(__DIR__ . '/../config/indexer.php', 'indexer');
+        
         $this->registerHtmlLoader();
         $this->registerRunCommand();
 
@@ -61,7 +63,7 @@ class IndexerServiceProvider extends ServiceProvider
     {
         $this->app->singleton('indexer.loader', function (Container $app) {
             return $app->make(
-                $app['config']['indexer.html_loader'] ?? FileContentHtmlLoader::class
+                $app['config']['indexer.html_loader']
             );
         });
 

--- a/src/IndexerServiceProvider.php
+++ b/src/IndexerServiceProvider.php
@@ -61,7 +61,7 @@ class IndexerServiceProvider extends ServiceProvider
     {
         $this->app->singleton('indexer.loader', function (Container $app) {
             return $app->make(
-                $app['config']['indexer.html_loader']
+                $app['config']['indexer.html_loader'] ?? FileContentHtmlLoader::class
             );
         });
 


### PR DESCRIPTION
This PR ~~adds a fallback html loader~~ as currently the package can not be installed successfully, as the registration fails - because it requires a published configuration (which can't be published until the package is successfully registered).

Updated:
Instead of a fallback I just added the appropriate setting to merge the included config which serves as a complete fallback for the registration of the packge  
 